### PR TITLE
gitignore doc/tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
The `doc/tags` file should never be added to git and having it always show up in `git status` is really distracting.
